### PR TITLE
Adding OP_RETURN transactions

### DIFF
--- a/lib/src/payments/embed.dart
+++ b/lib/src/payments/embed.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'package:meta/meta.dart';
+
+import '../models/networks.dart';
+import '../payments/index.dart' show PaymentData;
+import '../utils/script.dart' as bscript;
+import '../utils/constants/op.dart';
+
+class P2DATA {
+  String words;
+  PaymentData data;
+  NetworkType network;
+  P2DATA({@required words, network}) {
+    this.network = network ?? bitcoin;
+    this.words = words;
+    _init();
+  }
+
+  _init() {
+    if (words != null) {
+      if (words.length <= 79) { //TODO Replace with MAX_OP_RETURN_SIZE - 1 byte
+        _generateOutput(words);
+      } else {
+        throw new ArgumentError('Too much data');
+      }
+    } else {
+      throw new ArgumentError('Data to be embedded not found');
+    }
+  }
+
+  void _generateOutput(String words) {
+    data.output = bscript.compile([
+      OPS['OP_RETURN'],
+      utf8.encode(words)
+    ]);
+  }
+}

--- a/lib/src/transaction_builder.dart
+++ b/lib/src/transaction_builder.dart
@@ -1,4 +1,6 @@
+import 'dart:convert';
 import 'dart:typed_data';
+import 'package:bitcoin_flutter/src/utils/constants/op.dart';
 import 'package:meta/meta.dart';
 import 'package:hex/hex.dart';
 import 'package:bs58check/bs58check.dart' as bs58check;
@@ -102,6 +104,14 @@ class TransactionBuilder {
       throw new ArgumentError('No, this would invalidate signatures');
     }
     return _tx.addOutput(scriptPubKey, value);
+  }
+
+  int addNullOutput(String words) {
+    Uint8List scriptPubKey = bscript.compile([
+      OPS['OP_RETURN'],
+      utf8.encode(words)
+    ]);
+    return _tx.addOutput(scriptPubKey, 0);
   }
 
   int addInput(dynamic txHash, int vout,

--- a/lib/src/transaction_builder.dart
+++ b/lib/src/transaction_builder.dart
@@ -1,10 +1,7 @@
-import 'dart:convert';
 import 'dart:typed_data';
-import 'package:bitcoin_flutter/src/utils/constants/op.dart';
+import 'package:bitcoin_flutter/src/payments/embed.dart';
 import 'package:meta/meta.dart';
 import 'package:hex/hex.dart';
-import 'package:bs58check/bs58check.dart' as bs58check;
-import 'package:bech32/bech32.dart';
 import 'utils/script.dart' as bscript;
 import 'ecpair.dart';
 import 'models/networks.dart';
@@ -106,11 +103,9 @@ class TransactionBuilder {
     return _tx.addOutput(scriptPubKey, value);
   }
 
-  int addNullOutput(String words) {
-    Uint8List scriptPubKey = bscript.compile([
-      OPS['OP_RETURN'],
-      utf8.encode(words)
-    ]);
+  //Adding an OP_RETURN output
+  int addOutputData(String words) {
+    var scriptPubKey = P2DATA(words: words, network: this.network).data.output;
     return _tx.addOutput(scriptPubKey, 0);
   }
 


### PR DESCRIPTION
I'm tryng to build a proof of existence service based on the Peercoin blockchain so I need OP_RETURN transactions, I've tried to include this feature in the library following the structure of the other transactions.
I am currently not able to test the feature due to an exception:

type 'NetworkType' is not a subtype of type 'NetworkType' where
  NetworkType is from file:///Users/username/AndroidStudioProjects/bitcoin_flutter/lib/src/models/networks.dart
  NetworkType is from package:bitcoin_flutter/src/models/networks.dart